### PR TITLE
Dockerfile, spriter for newer canvas

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,9 @@
+FROM alpine:3.3
+RUN apk add --update bash make g++ gcc python nodejs git && rm -fr /var/cache/apk/*
+RUN apk add --update cairo-dev && rm -fr /var/cache/apk/*
+
+ADD ./ /opt/bauralax
+WORKDIR /opt/bauralax
+RUN npm install
+EXPOSE 3000
+CMD ["npm", "start"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ A simple capture the flag game using lots of resources. Still being developed...
 npm install
 grunt
 npm start
+
+Or:
+
+npm run docker-build
+npm run docker-run
 ```
 
 ##TODO

--- a/package.json
+++ b/package.json
@@ -5,7 +5,9 @@
   "main": "index.coffee",
   "scripts": {
     "server": "grunt http-server",
-    "start": "grunt start"
+    "start": "grunt start",
+    "docker-build": "docker build -t bauralax/server .",
+    "docker-run": "docker run -p 3000:3000 -ti bauralax/server"
   },
   "author": "@benkitzelman",
   "license": "ISC",
@@ -21,6 +23,6 @@
     "http-server": "~ 0.5.5",
     "lodash": "^3.10.1",
     "quintus": "^0.2.0",
-    "spriter": "0.2.4"
+    "spriter": "https://github.com/tristanstraub/spriter.git"
   }
 }


### PR DESCRIPTION
- Dockerfile for running server
- fork of spriter which works with newer node versions of node-canvas (otherwise you get a build error with node 4+)
- package.json scripts for creating and running docker image
